### PR TITLE
[loader] made MatrixLoader less verbose

### DIFF
--- a/src/component/loader/MatrixLoader.h
+++ b/src/component/loader/MatrixLoader.h
@@ -37,6 +37,8 @@ public:
     void getMatrix(EigenMatrixType& matrix);
     void setFileName(std::string fileName);
 
+    bool m_printLog = false;
+
 protected:
 
     unsigned int m_nbRows;

--- a/src/component/loader/MatrixLoader.inl
+++ b/src/component/loader/MatrixLoader.inl
@@ -41,7 +41,8 @@ void MatrixLoader<EigenMatrixType>::load(){
     {
         std::string lineValues;  // déclaration d'une chaîne qui contiendra la ligne lue
         unsigned int nbLine = 0;
-        msg_info("MatrixLoader") << "[MatrixLoader] Reading file " << m_fileName << " ...";
+        if (m_printLog)
+            msg_info("MatrixLoader") << "Reading file " << m_fileName << " ...";
         while (std::getline(modesFile, lineValues))
         {
             std::stringstream ssin(lineValues);

--- a/src/component/mapping/ModelOrderReductionMapping.inl
+++ b/src/component/mapping/ModelOrderReductionMapping.inl
@@ -52,6 +52,7 @@ void ModelOrderReductionMapping<TIn, TOut>::init()
     msg_info(this) << "Number of modes: "<<n_in<<" Number of FEM nodes: "<<n_out;
 
     MatrixLoader<Eigen::MatrixXd>* matLoader = new MatrixLoader<Eigen::MatrixXd>();
+    matLoader->m_printLog = notMuted();
     matLoader->setFileName(d_modesPath.getValue());
     msg_info(this) << "Name of data file read";
 


### PR DESCRIPTION
I don't know if there's a better way to do that, but I needed MatrixLoader to be less verbose. 
By displaying less info messages, it's easier to see the warnings. 