### PR TITLE
Make CollisionOBBCapsule package optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ find_package(SofaMiscMapping REQUIRED)
 find_package(SofaMiscCollision REQUIRED)
 find_package(Sofa.GL REQUIRED)
 find_package(CollisionOBBCapsule QUIET)
+if (NOT CollisionOBBCapsule_FOUND)
+    message(WARNING "The package CollisionOBBCapsule has not been found. It is required to compile all the features of ${PROJECT_NAME}")
+endif()
 
 option(USE_COMPRESSED_ROW_SPARSE "Use compressed row sparse format in the mappings" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(SofaMiscFem REQUIRED)
 find_package(SofaMiscMapping REQUIRED)
 find_package(SofaMiscCollision REQUIRED)
 find_package(Sofa.GL REQUIRED)
-find_package(CollisionOBBCapsule REQUIRED)
+find_package(CollisionOBBCapsule QUIET)
 
 option(USE_COMPRESSED_ROW_SPARSE "Use compressed row sparse format in the mappings" ON)
 
@@ -81,6 +81,11 @@ set(README_FILES
     README.md
     )
 
+
+if (CollisionOBBCapsule_FOUND)
+    list(APPEND SOURCE_FILES ${MOR_SRC}/component/contact/MORFrictionContact[OBBCapsule].cpp)
+endif()
+
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${README_FILES})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_MODELORDERREDUCTION")
@@ -91,8 +96,10 @@ target_link_libraries(${PROJECT_NAME}
     SofaConstraint SofaGeneralAnimationLoop  SofaGeneralSimpleFem SofaUserInteraction # SofaGeneral
     SofaMiscFem SofaMiscMapping SofaMiscCollision # SofaMisc
     Sofa.GL
-    CollisionOBBCapsule
     )
+if (CollisionOBBCapsule_FOUND)
+    target_link_libraries(${PROJECT_NAME} CollisionOBBCapsule)
+endif()
 
 # Config files and install rules for pythons scripts
 sofa_install_pythonscripts(PLUGIN_NAME ${PROJECT_NAME} PYTHONSCRIPTS_SOURCE_DIR "python")

--- a/src/ModelOrderReduction/component/contact/MORFrictionContact.cpp
+++ b/src/ModelOrderReduction/component/contact/MORFrictionContact.cpp
@@ -23,9 +23,6 @@
 #include <SofaMeshCollision/RigidContactMapper.inl>
 #include <SofaMeshCollision/BarycentricContactMapper.inl>
 
-#include <CollisionOBBCapsule/response/mapper/CapsuleContactMapper.h>
-#include <CollisionOBBCapsule/response/mapper/OBBContactMapper.h>
-
 namespace sofa::component::collision::geometry
 {
 
@@ -43,26 +40,11 @@ Creator<Contact::Factory, MORFrictionContact<TriangleCollisionModel<Vec3Types>, 
 Creator<Contact::Factory, MORFrictionContact<TriangleCollisionModel<Vec3Types>, TriangleCollisionModel<Vec3Types>> > TriangleTriangleMORFrictionContactClass("MORFrictionContact",true);
 Creator<Contact::Factory, MORFrictionContact<SphereCollisionModel<Vec3Types>, SphereCollisionModel<Vec3Types>> > SphereSphereMORFrictionContactClass("MORFrictionContact",true);
 Creator<Contact::Factory, MORFrictionContact<SphereCollisionModel<Vec3Types>, PointCollisionModel<Vec3Types>> > SpherePointMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, CapsuleCollisionModel<Vec3Types>> > CapsuleCapsuleMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, TriangleCollisionModel<Vec3Types>> > CapsuleTriangleMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, SphereCollisionModel<Vec3Types>> > CapsuleSphereMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<OBBCollisionModel<Rigid3Types>, OBBCollisionModel<Rigid3Types>> > OBBOBBMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<SphereCollisionModel<Vec3Types>, OBBCollisionModel<Rigid3Types>> > SphereOBBMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, OBBCollisionModel<Rigid3Types>> > CapsuleOBBMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<TriangleCollisionModel<Vec3Types>, OBBCollisionModel<Rigid3Types>> > TriangleOBBMORFrictionContactClass("MORFrictionContact",true);
 Creator<Contact::Factory, MORFrictionContact<RigidSphereModel, RigidSphereModel> > RigidSphereRigidSphereMORFrictionContactClass("MORFrictionContact",true);
 Creator<Contact::Factory, MORFrictionContact<SphereCollisionModel<Vec3Types>, RigidSphereModel> > SphereRigidSphereMORFrictionContactClass("MORFrictionContact",true);
 Creator<Contact::Factory, MORFrictionContact<LineCollisionModel<Vec3Types>, RigidSphereModel> > LineRigidSphereMORFrictionContactClass("MORFrictionContact",true);
 Creator<Contact::Factory, MORFrictionContact<TriangleCollisionModel<Vec3Types>, RigidSphereModel> > TriangleRigidSphereMORFrictionContactClass("MORFrictionContact",true);
 Creator<Contact::Factory, MORFrictionContact<RigidSphereModel, PointCollisionModel<Vec3Types>> > RigidSpherePointMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, RigidSphereModel> > CapsuleRigidSphereMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<RigidSphereModel, OBBCollisionModel<Rigid3Types>> > RigidSphereOBBMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Rigid3Types>, CapsuleCollisionModel<Rigid3Types>> > RigidCapsuleRigidCapsuleMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, CapsuleCollisionModel<Rigid3Types>> > CapsuleRigidCapsuleMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Rigid3Types>, TriangleCollisionModel<Vec3Types>> > RigidCapsuleTriangleMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Rigid3Types>, SphereCollisionModel<Vec3Types>> > RigidCapsuleSphereMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Rigid3Types>, OBBCollisionModel<Rigid3Types>> > RigidCapsuleOBBMORFrictionContactClass("MORFrictionContact",true);
-Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Rigid3Types>, RigidSphereModel> > RigidCapsuleRigidSphereMORFrictionContactClass("MORFrictionContact",true);
 
 
 } // namespace sofa::component::collision

--- a/src/ModelOrderReduction/component/contact/MORFrictionContact[OBBCapsule].cpp
+++ b/src/ModelOrderReduction/component/contact/MORFrictionContact[OBBCapsule].cpp
@@ -1,0 +1,50 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2019 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <ModelOrderReduction/component/contact/MORFrictionContact.inl>
+#include <CollisionOBBCapsule/response/mapper/CapsuleContactMapper.h>
+#include <CollisionOBBCapsule/response/mapper/OBBContactMapper.h>
+
+namespace sofa::component::collision::geometry
+{
+
+using sofa::core::collision::Contact;
+using sofa::defaulttype::Vec3Types;
+using sofa::defaulttype::Rigid3Types;
+
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, CapsuleCollisionModel<Vec3Types>> > CapsuleCapsuleMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, TriangleCollisionModel<Vec3Types>> > CapsuleTriangleMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, SphereCollisionModel<Vec3Types>> > CapsuleSphereMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<OBBCollisionModel<Rigid3Types>, OBBCollisionModel<Rigid3Types>> > OBBOBBMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<SphereCollisionModel<Vec3Types>, OBBCollisionModel<Rigid3Types>> > SphereOBBMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, OBBCollisionModel<Rigid3Types>> > CapsuleOBBMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<TriangleCollisionModel<Vec3Types>, OBBCollisionModel<Rigid3Types>> > TriangleOBBMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, RigidSphereModel> > CapsuleRigidSphereMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<RigidSphereModel, OBBCollisionModel<Rigid3Types>> > RigidSphereOBBMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Rigid3Types>, CapsuleCollisionModel<Rigid3Types>> > RigidCapsuleRigidCapsuleMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Vec3Types>, CapsuleCollisionModel<Rigid3Types>> > CapsuleRigidCapsuleMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Rigid3Types>, TriangleCollisionModel<Vec3Types>> > RigidCapsuleTriangleMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Rigid3Types>, SphereCollisionModel<Vec3Types>> > RigidCapsuleSphereMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Rigid3Types>, OBBCollisionModel<Rigid3Types>> > RigidCapsuleOBBMORFrictionContactClass("MORFrictionContact",true);
+Creator<Contact::Factory, MORFrictionContact<CapsuleCollisionModel<Rigid3Types>, RigidSphereModel> > RigidCapsuleRigidSphereMORFrictionContactClass("MORFrictionContact",true);
+
+
+}


### PR DESCRIPTION
In https://github.com/sofa-framework/sofa/pull/2820, OBB and capsule primitives have been moved into a dedicated plugin. This plugin is not activated by default.