### PR TITLE
GitHub actions based on SOFA v22.06

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-10.15]  
-        sofa_branch: [master]
+        sofa_branch: [v22.06]
 
     steps:
       - name: Setup SOFA and environment


### PR DESCRIPTION
Make GitHub actions based on SOFA v22.06 instead of master