### PR TITLE
Fix v23.06 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,8 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           tag_name: release-${{ github.ref_name }}
-          fail_on_unmatched_files: true 
+          fail_on_unmatched_files: false
           files: |
             artifacts/ModelOrderReduction_*_Linux.zip
             artifacts/ModelOrderReduction_*_Windows.zip
+            artifacts/ModelOrderReduction_*_macOS.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
           name: ${{ github.ref_name }}
           tag_name: release-${{ github.ref_name }}
           fail_on_unmatched_files: false
+          target_commitish: ${{ github.ref_name }}
           files: |
             artifacts/ModelOrderReduction_*_Linux.zip
             artifacts/ModelOrderReduction_*_Windows.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-11]  
-        sofa_branch: [master]
+        sofa_branch: [v23.06]
 
     steps:
       - name: (Mac) Workaround for homebrew


### PR DESCRIPTION
This PR fixes 3 points in the v23.06 CI:
- Invalid release branch : should be `v23.06` instead of `master`
- The `softprops/action-gh-release` Github action used in the CI to deploy assets was incorrectly configured to the `master` branch (default behavior), instead of the current release set by the `sofa_branch` field in the `build-and-test` matrix. This lead to the following undesired behavior:
  - source code archives (zip and tar) were generated from master branch instead of release branch. Other assets (releases for Windows, Linux and MacOS) were generated from correct branch.
  - release tag pushed by this action (tag in the form `release-<version>`) was incorrectly set to `master` branch, which is invalid when current release is not `master` (such as `v<version>`)
- Allow the creation of the release to continue on failure, which typically occurs if one asset is missing such the macOS archive as the mac CI is down. 

Similarly to what has been proposed to SofaPython3, SoftRobots, STLIB, Cosserat and BeamAdapter plugins.