### PR TITLE
Add compatibility layer for buildStiffnessMatrix

### DIFF
--- a/src/ModelOrderReduction/component/forcefield/HyperReducedHexahedronFEMForceField.h
+++ b/src/ModelOrderReduction/component/forcefield/HyperReducedHexahedronFEMForceField.h
@@ -144,6 +144,7 @@ public:
     // getPotentialEnergy is implemented for polar method
 
     void addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/src/ModelOrderReduction/component/forcefield/HyperReducedHexahedronFEMForceField.inl
+++ b/src/ModelOrderReduction/component/forcefield/HyperReducedHexahedronFEMForceField.inl
@@ -451,6 +451,13 @@ void HyperReducedHexahedronFEMForceField<DataTypes>::addKToMatrix(const core::Me
     }
 }
 
+template <class DataTypes>
+void HyperReducedHexahedronFEMForceField<DataTypes>::buildStiffnessMatrix(
+    core::behavior::StiffnessMatrix* matrix)
+{
+    core::behavior::ForceField<DataTypes>::buildStiffnessMatrix(matrix);
+}
+
 
 template<class DataTypes>
 void HyperReducedHexahedronFEMForceField<DataTypes>::draw(const core::visual::VisualParams* vparams)

--- a/src/ModelOrderReduction/component/forcefield/HyperReducedRestShapeSpringsForceField.h
+++ b/src/ModelOrderReduction/component/forcefield/HyperReducedRestShapeSpringsForceField.h
@@ -106,6 +106,8 @@ public:
     /// Brings ForceField contribution to the global system stiffness matrix.
     virtual void addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix ) override;
 
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override;
+
     virtual void draw(const core::visual::VisualParams* vparams) override;
 
     const DataVecCoord* getExtPosition() const;

--- a/src/ModelOrderReduction/component/forcefield/HyperReducedRestShapeSpringsForceField.inl
+++ b/src/ModelOrderReduction/component/forcefield/HyperReducedRestShapeSpringsForceField.inl
@@ -488,6 +488,13 @@ void HyperReducedRestShapeSpringsForceField<DataTypes>::addKToMatrix(const Mecha
     }
 }
 
+template <class DataTypes>
+void HyperReducedRestShapeSpringsForceField<DataTypes>::buildStiffnessMatrix(
+    core::behavior::StiffnessMatrix* matrix)
+{
+    core::behavior::ForceField<DataTypes>::buildStiffnessMatrix(matrix);
+}
+
 } // namespace sofa::component::solidmechanics::spring
 
 

--- a/src/ModelOrderReduction/component/forcefield/HyperReducedTetrahedralCorotationalFEMForceField.h
+++ b/src/ModelOrderReduction/component/forcefield/HyperReducedTetrahedralCorotationalFEMForceField.h
@@ -131,6 +131,7 @@ public:
     virtual void addDForce(const core::MechanicalParams* mparams, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
 
     virtual void addKToMatrix(sofa::linearalgebra::BaseMatrix *m, SReal kFactor, unsigned int &offset) override;
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/src/ModelOrderReduction/component/forcefield/HyperReducedTetrahedralCorotationalFEMForceField.inl
+++ b/src/ModelOrderReduction/component/forcefield/HyperReducedTetrahedralCorotationalFEMForceField.inl
@@ -756,4 +756,12 @@ void HyperReducedTetrahedralCorotationalFEMForceField<DataTypes>::addKToMatrix(s
         }
     }
 }
+
+template <class DataTypes>
+void HyperReducedTetrahedralCorotationalFEMForceField<DataTypes>::
+buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix)
+{
+    core::behavior::ForceField<DataTypes>::buildStiffnessMatrix(matrix);
+}
+
 } // namespace sofa::component::solidmechanics::fem::elastic

--- a/src/ModelOrderReduction/component/forcefield/HyperReducedTetrahedronHyperelasticityFEMForceField.h
+++ b/src/ModelOrderReduction/component/forcefield/HyperReducedTetrahedronHyperelasticityFEMForceField.h
@@ -118,6 +118,7 @@ public:
     virtual void addForce(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataVecDeriv& d_f, const DataVecCoord& d_x, const DataVecDeriv& d_v) override;
     virtual void addDForce(const core::MechanicalParams* mparams /* PARAMS FIRST */, DataVecDeriv& d_df, const DataVecDeriv& d_dx) override;
     virtual void addKToMatrix(sofa::linearalgebra::BaseMatrix *mat, SReal k, unsigned int &offset) override;
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override;
 
     void draw(const core::visual::VisualParams* vparams) override;
 

--- a/src/ModelOrderReduction/component/forcefield/HyperReducedTetrahedronHyperelasticityFEMForceField.inl
+++ b/src/ModelOrderReduction/component/forcefield/HyperReducedTetrahedronHyperelasticityFEMForceField.inl
@@ -573,6 +573,12 @@ void HyperReducedTetrahedronHyperelasticityFEMForceField<DataTypes>::addKToMatri
     m_edgeInfo.endEdit();
 }
 
+template <class DataTypes>
+void HyperReducedTetrahedronHyperelasticityFEMForceField<DataTypes>::
+buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix)
+{
+    core::behavior::ForceField<DataTypes>::buildStiffnessMatrix(matrix);
+}
 
 
 template<class DataTypes>


### PR DESCRIPTION
For components not implementing it already

Those component will need to implement `buildStiffnessMatrix` properly. This PR is just a workaround to make it work in the meantime.