### PR TITLE
[examples] Fix unnecessary use of UncoupledConstraintCorrection

### DIFF
--- a/examples/others/SphereOnAPlane/softSphereFalling.pyscn
+++ b/examples/others/SphereOnAPlane/softSphereFalling.pyscn
@@ -112,9 +112,5 @@ def createScene(rootNode):
     planeNode.addObject('Mesh', src="@loader")
     planeNode.addObject('MechanicalObject', src="@loader", rotation="0 0 0", translation="0 0 0", scale="1")
     planeNode.addObject('TriangleCollisionModel',simulated="0", moving="0",group="1",name='TriPlane')
-    #planeNode.addObject('LineCollisionModel',simulated="0", moving="0",group="1")
-    #planeNode.addObject('PointCollisionModel',simulated="0", moving="0",group="1")
-    #planeNode.addObject('OglModel',name="Visual", fileMesh="mesh/floorFlat.obj", color="1 0 0 1",rotation=rotation, translation="0 0 0", scale="1")
-    planeNode.addObject('UncoupledConstraintCorrection')
 
     return rootNode

--- a/examples/softRobots/multiGait/multiGait.py
+++ b/examples/softRobots/multiGait/multiGait.py
@@ -174,6 +174,5 @@ def createScene(rootNode):
     planeNode.addObject('PointCollisionModel', simulated="0", moving="0", group="1")
     planeNode.addObject('OglModel', name="Visual", fileMesh="mesh/floorFlat.obj", color="1 0 0 1", rotation="90 0 0",
                            translation="0 35 -1", scale="15")
-    planeNode.addObject('UncoupledConstraintCorrection')
 
     return rootNode


### PR DESCRIPTION
Two scenes were rising warnings due to the use of a UncoupledConstraintCorrection while the node was not containing a solver (since the object was not moving/simulated). Towards a greener dashboard :green_circle: 

Tested on CI in https://github.com/sofa-framework/sofa/pull/4687