### PR TITLE
[Scripts] Remove need of PyQt5 if gui is not used

### DIFF
--- a/python/mor/gui/utility.py
+++ b/python/mor/gui/utility.py
@@ -202,26 +202,6 @@ def removeLine(tab,rm=False):
         tab.removeRow(row)
         return row
 
-def update_progress(progress):
-    barLength = 50 # Modify this to change the length of the progress bar
-    status = "Compute Weight&RID"
-    if isinstance(progress, int):
-        progress = float(progress)
-    if not isinstance(progress, float):
-        progress = 0
-        status = "error: progress var must be float\r\n"
-    if progress < 0:
-        progress = 0
-        status = "Halt...\r\n"
-    if progress > 1:
-        progress = 1
-    block = int(round(barLength*progress))
-    text = "\r[{0}] {1}% {2}".format( "#"*block + "-"*(barLength-block), progress*100, status)
-    if progress == 1 :
-        text =  text+"\n"
-    sys.stdout.write(text)
-    sys.stdout.flush()
-
 def left(lineEdit):
     newTxt = str(lineEdit.text())
     if newTxt:

--- a/python/mor/reduction/script/ReadGieFileAndComputeRIDandWeights.py
+++ b/python/mor/reduction/script/ReadGieFileAndComputeRIDandWeights.py
@@ -12,7 +12,8 @@ from sys import argv
 path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(path+'/../../gui')
 
-import utility as u
+from mor.utility import utility as util
+
 
 def errDif(G, xi, b):
     return np.linalg.norm(G.dot(xi) - b)
@@ -33,7 +34,7 @@ def selectECSW(G,b,tau,verbose):
         if verbose :
             print ("Current Error: ", currentValue,"Target Error:", valTarget)
         else :
-            u.update_progress( round( ( 100 - ((currentValue - valTarget)*100) / marge) / 100 , 4) )
+            util.update_progress( round( ( 100 - ((currentValue - valTarget)*100) / marge) / 100 , 4) )
 
         vecDiff = b - G.dot(xi)
         GT = np.transpose(G)

--- a/python/mor/reduction/script/ReadGieFileAndComputeRIDandWeights.py
+++ b/python/mor/reduction/script/ReadGieFileAndComputeRIDandWeights.py
@@ -9,9 +9,6 @@ import numpy as np
 import os , sys
 from sys import argv
 
-path = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(path+'/../../gui')
-
 from mor.utility import utility as util
 
 

--- a/tools/modelOrderReduction.py
+++ b/tools/modelOrderReduction.py
@@ -31,9 +31,12 @@ import sys
 path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(path+'/../python') # TO CHANGE
 
+useGui = True
 
 # MOR IMPORT
-from mor.gui import utility
+if useGui:
+    from mor.gui import utility
+
 from mor.reduction import ReduceModel
 from mor.reduction.container import ObjToAnimate
 
@@ -41,14 +44,14 @@ from mor.reduction.container import ObjToAnimate
 ####################       PARAMETERS       ###########################
 
 # Select Output Dir and original scene name & path
-from PyQt5 import QtWidgets
-app = QtWidgets.QApplication(sys.argv)
-
-originalScene = utility.openFileName('Select the SOFA scene you want to reduce')
-outputDir = utility.openDirName('Select the directory that will contain all the results')
-
-# originalScene = "/home/felix_v/SOFA/plugins/ModelOrderReduction/tools/test/sofa_test_scene/diamondRobot.py"
-# outputDir = "/home/felix_v/SOFA/plugins/ModelOrderReduction/tools/test/test_diamond"
+if useGui:
+    from PyQt5 import QtWidgets
+    app = QtWidgets.QApplication(sys.argv)
+    originalScene = utility.openFileName('Select the SOFA scene you want to reduce')
+    outputDir = utility.openDirName('Select the directory that will contain all the results')
+else:
+    originalScene = "/home/felix_v/SOFA/plugins/ModelOrderReduction/tools/test/sofa_test_scene/diamondRobot.py"
+    outputDir = "/home/felix_v/SOFA/plugins/ModelOrderReduction/tools/test/test_diamond"
 
 phasesToExecute = None
 

--- a/tools/modelOrderReduction.py
+++ b/tools/modelOrderReduction.py
@@ -50,8 +50,8 @@ if useGui:
     originalScene = utility.openFileName('Select the SOFA scene you want to reduce')
     outputDir = utility.openDirName('Select the directory that will contain all the results')
 else:
-    originalScene = "/home/felix_v/SOFA/plugins/ModelOrderReduction/tools/test/sofa_test_scene/diamondRobot.py"
-    outputDir = "/home/felix_v/SOFA/plugins/ModelOrderReduction/tools/test/test_diamond"
+    originalScene = None # replace with absolute path to your python SOFA scene
+    outputDir = None # replace with path to folder where results will be exported
 
 phasesToExecute = None
 


### PR DESCRIPTION
Method `update_progress` was present twice in the code: One in the `mor/gui/utility.py` and one in `mor/utility/utility.py`.

Only keep the one in gui/utility.py as it is bringing visual feedback for the UI. 

This allows to use the [tools/modelOrderReduction.py](https://github.com/SofaDefrost/ModelOrderReduction/compare/master...InfinyTech3D:ModelOrderReduction:nogui#diff-065fdee9ecd549d0cf73a359a1e3944b5b270ec1dd0fdf47a5a38e4d4a52cf4b) without gui to faster run benchmarks.