### PR TITLE
Remove redundant Data properties in HyperReducedTetrahedralCorotationalFEMForceField

### DIFF
--- a/src/ModelOrderReduction/component/forcefield/HyperReducedTetrahedralCorotationalFEMForceField.inl
+++ b/src/ModelOrderReduction/component/forcefield/HyperReducedTetrahedralCorotationalFEMForceField.inl
@@ -37,10 +37,6 @@ template< class DataTypes>
 HyperReducedTetrahedralCorotationalFEMForceField<DataTypes>::HyperReducedTetrahedralCorotationalFEMForceField()
 {
     this->addAlias(&_assembling, "assembling");
-    _poissonRatio.setWidget("poissonRatio");
-
-    _poissonRatio.setRequired(true);
-    _youngModulus.setRequired(true);
 }
 
 template <class DataTypes>


### PR DESCRIPTION
Not needed with https://github.com/sofa-framework/sofa/pull/4778