### PR TITLE
Remove deprecated python2.7 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,6 @@ if (CollisionOBBCapsule_FOUND)
 endif()
 
 # Config files and install rules for pythons scripts
-sofa_install_pythonscripts(PLUGIN_NAME ${PROJECT_NAME} PYTHONSCRIPTS_SOURCE_DIR "python")
-
 find_file(SofaPython3Tools NAMES "SofaPython3/lib/cmake/SofaPython3/SofaPython3Tools.cmake")
 if(SofaPython3Tools)
     message("-- Found SofaPython3Tools.")


### PR DESCRIPTION
Current version still installs python scripts in `lib/python2.7` in addition to `lib/python3.x` folder (depending on user python 3.x version installed).
We should remove deprecated python2.7 installation.