### PR TITLE
SOFA class baseconstraint

### DIFF
--- a/src/ModelOrderReduction/component/contact/MORUnilateralInteractionConstraint.h
+++ b/src/ModelOrderReduction/component/contact/MORUnilateralInteractionConstraint.h
@@ -73,17 +73,17 @@ public:
     typedef typename Coord::value_type Real;
     typedef typename core::behavior::MechanicalState<DataTypes> MechanicalState;
 
-    typedef core::behavior::BaseConstraint::ConstraintBlockInfo ConstraintBlockInfo;
-    typedef core::behavior::BaseConstraint::PersistentID PersistentID;
-    typedef core::behavior::BaseConstraint::ConstCoord ConstCoord;
-    typedef core::behavior::BaseConstraint::ConstDeriv ConstDeriv;
-    typedef core::behavior::BaseConstraint::ConstArea ConstArea;
+    typedef core::behavior::BaseLagrangianConstraint::ConstraintBlockInfo ConstraintBlockInfo;
+    typedef core::behavior::BaseLagrangianConstraint::PersistentID PersistentID;
+    typedef core::behavior::BaseLagrangianConstraint::ConstCoord ConstCoord;
+    typedef core::behavior::BaseLagrangianConstraint::ConstDeriv ConstDeriv;
+    typedef core::behavior::BaseLagrangianConstraint::ConstArea ConstArea;
 
-    typedef core::behavior::BaseConstraint::VecConstraintBlockInfo VecConstraintBlockInfo;
-    typedef core::behavior::BaseConstraint::VecPersistentID VecPersistentID;
-    typedef core::behavior::BaseConstraint::VecConstCoord VecConstCoord;
-    typedef core::behavior::BaseConstraint::VecConstDeriv VecConstDeriv;
-    typedef core::behavior::BaseConstraint::VecConstArea VecConstArea;
+    typedef core::behavior::BaseLagrangianConstraint::VecConstraintBlockInfo VecConstraintBlockInfo;
+    typedef core::behavior::BaseLagrangianConstraint::VecPersistentID VecPersistentID;
+    typedef core::behavior::BaseLagrangianConstraint::VecConstCoord VecConstCoord;
+    typedef core::behavior::BaseLagrangianConstraint::VecConstDeriv VecConstDeriv;
+    typedef core::behavior::BaseLagrangianConstraint::VecConstArea VecConstArea;
 
     typedef core::objectmodel::Data<VecCoord>		DataVecCoord;
     typedef core::objectmodel::Data<VecDeriv>		DataVecDeriv;


### PR DESCRIPTION
Rename after https://github.com/sofa-framework/sofa/pull/5423. Don't merge until this PR is merged